### PR TITLE
bump node count to three

### DIFF
--- a/rabbitmq.yaml
+++ b/rabbitmq.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: rabbitmq
 spec:
-  replicas: 2
+  replicas: 3
   resources:
     requests:
       cpu: 1000m


### PR DESCRIPTION
> Because several features (e.g. [quorum queues](https://www.rabbitmq.com/docs/quorum-queues), [client tracking in MQTT](https://www.rabbitmq.com/docs/mqtt)) require a consensus between cluster members, odd numbers of cluster nodes are highly recommended: 1, 3, 5, 7 and so on.
>
> Two node clusters are highly recommended against since it's impossible for cluster nodes to identify a majority and form a consensus in case of connectivity loss. For example, when the two nodes lose connectivity MQTT client connections won't be accepted, quorum queues would lose their availability, and so on.

https://www.rabbitmq.com/docs/clustering#node-count